### PR TITLE
Sockets usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,27 @@ Actually we supports two adapters
 
 ### Using UDP/IP Adapter
 
-Actually "socket" php library is used for UDP/IP adapter
 
+In order to use the UDP/IP adapter your must have PHP compiled with the `sockets` extension.
+
+To verify if you have the `sockets` extension just issue a:
+
+```bash
+php -m | grep sockets
 ```
+
+If you don't have the `sockets` extension, you can proceed in two ways:
+
+- Recompile your PHP whith the `--enable-sockets` flag
+- Or just compile the `sockets` extension extracting it from the PHP source.  
+  1. Download the source relative to the PHP version that you on from [here](https://github.com/php/php-src/releases)
+  2. Enter in the `ext/sockets` directory
+  3. Issue a `phpize && ./configure && make -j && sudo make install`
+  4. Add `extension=sockets.so` to your php.ini
+
+**Usage**
+
+```php
 $options = new Options();
 $adapter = new UdpAdapter($options);
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require-dev": {
         "phpspec/phpspec": "2.*",
         "phpunit/phpunit": "4.*",
-        "athletic/athletic": "~0.1"
+        "athletic/athletic": "~0.1",
+        "ext-sockets": "*"
     },
     "homepage": "http://www.corley.it/",
     "keywords": ["influxdb", "udp", "sdk"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ff63d84450d0ba675f2231b385344e9a",
+    "hash": "b8984634251cdc10c12d585b63e98fbd",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1627,18 +1627,12 @@
             "time": "2013-05-29 02:35:23"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
     "prefer-stable": false,
-    "platform": [
-
-    ],
-    "platform-dev": [
-
-    ]
+    "platform": [],
+    "platform-dev": {
+        "ext-sockets": "*"
+    }
 }


### PR DESCRIPTION
I added `ext-sockets` to the require-dev section of the composer.json because even if this can be used without the `sockets` extension when in development tests can't run without it.

I also updated the documentation to explain how to obtain the `sockets` extension even if was not built with PHP.
