### PR TITLE
Client options usage

### DIFF
--- a/src/Adapter/AdapterAbstract.php
+++ b/src/Adapter/AdapterAbstract.php
@@ -19,7 +19,7 @@ abstract class AdapterAbstract implements WritableInterface
         return $this->options;
     }
 
-    protected function getMessageDefaults()
+    private function getMessageDefaults()
     {
         return [
             "database" => $this->getOptions()->getDatabase(),
@@ -34,6 +34,12 @@ abstract class AdapterAbstract implements WritableInterface
     {
         if (!array_key_exists("points", $message)) {
             return;
+        }
+
+        $message = array_replace_recursive($this->getMessageDefaults(), $message);
+
+        if (array_key_exists("tags", $message)) {
+            $message["tags"] = array_replace_recursive($this->getOptions()->getTags(), $message["tags"]);
         }
 
         $unixepoch = (int)(microtime(true) * 1e9);

--- a/src/Adapter/GuzzleAdapter.php
+++ b/src/Adapter/GuzzleAdapter.php
@@ -17,17 +17,11 @@ class GuzzleAdapter extends AdapterAbstract implements QueryableInterface
 
     public function send(array $message)
     {
-        $message = array_replace_recursive($this->getMessageDefaults(), $message);
-
-        if (!count($message["tags"])) {
-            unset($message["tags"]);
-        }
-
         $httpMessage = [
             "auth" => [$this->getOptions()->getUsername(), $this->getOptions()->getPassword()],
             'query' => [
-                "db" => $message["database"],
-                "retentionPolicy" => $message["retentionPolicy"],
+                "db" => $this->getOptions()->getDatabase(),
+                "retentionPolicy" => $this->getOptions()->getRetentionPolicy(),
             ],
             "body" => $this->messageToLineProtocol($message)
         ];

--- a/src/Adapter/UdpAdapter.php
+++ b/src/Adapter/UdpAdapter.php
@@ -5,12 +5,6 @@ class UdpAdapter extends AdapterAbstract
 {
     public function send(array $message)
     {
-        $message = array_replace_recursive($this->getMessageDefaults(), $message);
-
-        if (array_key_exists("tags", $message)) {
-            $message["tags"] = array_replace_recursive($this->getOptions()->getTags(), $message["tags"]);
-        }
-
         $message = $this->messageToLineProtocol($message);
 
         $this->write($message);

--- a/src/Client.php
+++ b/src/Client.php
@@ -31,7 +31,6 @@ class Client
         $data = $name;
         if (!is_array($name)) {
             $data =[];
-
             $data['points'][0]['measurement'] = $name;
             $data['points'][0]['fields'] = $values;
         }

--- a/tests/unit/Adapter/GuzzleAdapterTest.php
+++ b/tests/unit/Adapter/GuzzleAdapterTest.php
@@ -111,27 +111,6 @@ class GuzzleAdapterTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function testDefaultOptionOverwrite()
-    {
-        $options = new Options();
-        $options->setDatabase("db");
-        $httpClient = $this->prophesize("GuzzleHttp\\Client");
-        $httpClient->post(Argument::Any(), [
-            "auth" => ["root", "root"],
-            "query" => [
-                "db" => "mydb",
-                "retentionPolicy" => "myPolicy",
-            ],
-            "body" => null,
-        ])->shouldBeCalledTimes(1);
-
-        $adapter = new InfluxHttpAdapter($httpClient->reveal(), $options);
-        $adapter->send([
-            "database" => "mydb",
-            "retentionPolicy" => "myPolicy"
-        ]);
-    }
-
     public function testEmptyTagsFieldIsRemoved()
     {
         $options = new Options();


### PR DESCRIPTION
For HTTP adapter you can overwrite some options, that is useless because
you can effectively overwrite the `Options` structure.