### PR TITLE
Test against InfluxDB nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,10 @@ after_script:
 
 matrix:
   allow_failures:
-    - php: 7
+    - env: GUZZLE_VERSION="~4" INFLUXDB_DEB="influxdb_nightly_amd64.deb"
+    - env: GUZZLE_VERSION="~5" INFLUXDB_DEB="influxdb_nightly_amd64.deb"
+    - env: GUZZLE_VERSION="~6" INFLUXDB_DEB="influxdb_nightly_amd64.deb"
+
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
   - GUZZLE_VERSION="~4" INFLUXDB_DEB="influxdb_0.9.3_amd64.deb"
   - GUZZLE_VERSION="~5" INFLUXDB_DEB="influxdb_0.9.3_amd64.deb"
   - GUZZLE_VERSION="~6" INFLUXDB_DEB="influxdb_0.9.3_amd64.deb"
+  - GUZZLE_VERSION="~4" INFLUXDB_DEB="influxdb_nightly_amd64.deb"
+  - GUZZLE_VERSION="~5" INFLUXDB_DEB="influxdb_nightly_amd64.deb"
+  - GUZZLE_VERSION="~6" INFLUXDB_DEB="influxdb_nightly_amd64.deb"
 
 before_install:
   - sudo apt-get update


### PR DESCRIPTION
Actually we test only the current version, we should also run the testsuite against InfluxDB nightly builds 