### PR TITLE
Extract data-type management to callables

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,23 @@ $client->mark("serie", [
 ]);
 ```
 
-**Pay attention! This option: `setForceIntegers` will be removed when InfluxDB reaches a stable release `1.*` and we will enable the data type detection by default (BC BREAK)**
+**Pay attention! This option: `setForceIntegers` will be removed when InfluxDB
+reaches a stable release `1.*` and we will enable the data type detection by
+default (BC BREAK)**
+
+### Force data type
+
+If you want to ensure that a type is effectively parsed correctly you can force
+it directly during the send operation
+
+```php
+$client->mark("serie", [
+    "value"  => new IntType(12),  // Marked as int64
+    "elem"   => new FloatType(12.4), // Marked as float64
+    "status" => new BoolType(true), // Marked as boolean
+    "line"   => new StringType("12w"), // Marked as string
+]);
+```
 
 ### Query Builder
 

--- a/src/Adapter/AdapterAbstract.php
+++ b/src/Adapter/AdapterAbstract.php
@@ -71,25 +71,41 @@ abstract class AdapterAbstract implements WritableInterface
 
     protected function pointsToString(array $elements)
     {
-        $options = $this->getOptions();
-        array_walk($elements, function(&$value, $key) use ($options) {
-            switch(gettype($value)) {
-                case "string":
-                    $value = "\"{$value}\"";
-                    break;
-                case "boolean":
-                    $value = ($value) ? "true" : "false";
-                    break;
-                case "integer":
-                    $value = ($options->getForceIntegers()) ? "{$value}i" : $value;
-                    break;
-                default:
-                    break;
+        array_walk($elements, function(&$value, $key) {
+            $dataType = gettype($value);
+            if (!in_array($dataType, ["string", "double", "boolean", "integer"])) {
+                $dataType = "serializable";
             }
-
+            $dataType = ucfirst($dataType);
+            $value = call_user_func([$this, "convert{$dataType}"], $value);
             $value = "{$key}={$value}";
         });
 
         return implode(",", $elements);
+    }
+
+    protected function convertSerializable($value)
+    {
+        return "{$value}";
+    }
+
+    protected function convertString($value)
+    {
+        return "\"{$value}\"";
+    }
+
+    protected function convertInteger($value)
+    {
+        return (($this->getOptions()->getForceIntegers()) ? "{$value}i" : $value);
+    }
+
+    protected function convertDouble($value)
+    {
+        return $value;
+    }
+
+    protected function convertBoolean($value)
+    {
+        return (($value) ? "true" : "false");
     }
 }

--- a/src/Type/BoolType.php
+++ b/src/Type/BoolType.php
@@ -1,0 +1,18 @@
+<?php
+namespace InfluxDB\Type;
+
+class BoolType
+{
+    private $num;
+
+    public function __construct($value)
+    {
+        $this->num = boolval((string)$value);
+    }
+
+    public function __toString()
+    {
+        return ($this->num) ? "true" : "false";
+    }
+}
+

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -1,0 +1,18 @@
+<?php
+namespace InfluxDB\Type;
+
+class FloatType
+{
+    private $num;
+
+    public function __construct($value)
+    {
+        $this->num = floatval((string)$value);
+    }
+
+    public function __toString()
+    {
+        return (string)$this->num;
+    }
+}
+

--- a/src/Type/IntType.php
+++ b/src/Type/IntType.php
@@ -1,0 +1,17 @@
+<?php
+namespace InfluxDB\Type;
+
+class IntType
+{
+    private $num;
+
+    public function __construct($value)
+    {
+        $this->num = intval((string)$value);
+    }
+
+    public function __toString()
+    {
+        return $this->num . "i";
+    }
+}

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -1,0 +1,18 @@
+<?php
+namespace InfluxDB\Type;
+
+class StringType
+{
+    private $num;
+
+    public function __construct($value)
+    {
+        $this->num = strval($value);
+    }
+
+    public function __toString()
+    {
+        return "\"" . $this->num . "\"";
+    }
+}
+

--- a/tests/unit/Adapter/AdapterAbstractTest.php
+++ b/tests/unit/Adapter/AdapterAbstractTest.php
@@ -3,6 +3,8 @@ namespace InfluxDB\Adapter;
 
 use ReflectionMethod;
 use InfluxDB\Options;
+use InfluxDB\Type\IntType;
+use InfluxDB\Type\FloatType;
 
 class AdapterAbstractTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,6 +38,12 @@ class AdapterAbstractTest extends \PHPUnit_Framework_TestCase
             [["one" => (double)12, "three" => 14], "one=12,three=14i", (new Options())->setForceIntegers(true)],
             [["one" => (double)12, "three" => (double)14], "one=12,three=14", (new Options())->setForceIntegers(true)],
             [["one" => (double)"12", "three" => (int)"14"], "one=12,three=14i", (new Options())->setForceIntegers(true)],
+            [["one" => (double)"12", "three" => new IntType("14")], "one=12,three=14i", (new Options())->setForceIntegers(true)],
+            [["one" => (double)"12", "three" => new IntType(14.12)], "one=12,three=14i", (new Options())->setForceIntegers(true)],
+            [["one" => (double)"12", "three" => new IntType(14)], "one=12,three=14i", (new Options())->setForceIntegers(true)],
+            [["one" => (double)"12", "three" => new FloatType(14)], "one=12,three=14", (new Options())->setForceIntegers(true)],
+            [["one" => (double)"12", "three" => new FloatType("14")], "one=12,three=14", (new Options())->setForceIntegers(true)],
+            [["one" => (double)"12", "three" => new FloatType("14.123")], "one=12,three=14.123", (new Options())->setForceIntegers(true)],
         ];
     }
 }

--- a/tests/unit/Type/BoolTypeTest.php
+++ b/tests/unit/Type/BoolTypeTest.php
@@ -1,0 +1,30 @@
+<?php
+namespace InfluxDB\Type;
+
+class BoolTypeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider boolProvider
+     */
+    public function testConversions($in, $out)
+    {
+        $this->assertEquals($out, new BoolType($in));
+    }
+
+    public function boolProvider()
+    {
+        return [
+            [true, "true"],
+            ["1", "true"],
+            [1, "true"],
+            ["something", "true"],
+            [12, "true"],
+
+            [false, "false"],
+            ["0", "false"],
+            [0, "false"],
+            [null, "false"],
+        ];
+    }
+}
+

--- a/tests/unit/Type/FloatTypeTest.php
+++ b/tests/unit/Type/FloatTypeTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace InfluxDB\Type;
+
+class FloatTypeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider floatProvider
+     */
+    public function testConversion($in, $out)
+    {
+        $in = new FloatType($in);
+        $this->assertSame($out, (string)$in);
+    }
+
+    public function floatProvider()
+    {
+        return [
+            [12.12, "12.12"],
+            ["12.12", "12.12"],
+            ["12", "12"],
+            [12, "12"],
+            [new FloatType("12.12"), "12.12"],
+            [new FloatType(12.12), "12.12"],
+            ["invalid", "0"],
+            [null, "0"],
+            [new FloatType("invalid"), "0"],
+            [new FloatType(null), "0"],
+            [true, "1"],
+            [false, "0"],
+        ];
+    }
+}

--- a/tests/unit/Type/IntTypeTest.php
+++ b/tests/unit/Type/IntTypeTest.php
@@ -1,0 +1,30 @@
+<?php
+namespace InfluxDB\Type;
+
+class IntTypeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider intProvider
+     */
+    public function testConversions($in, $out)
+    {
+        $this->assertEquals($out, new IntType($in));
+    }
+
+    public function intProvider()
+    {
+        return [
+            ["12", "12i"],
+            [12, "12i"],
+            [12.12, "12i"],
+            [new IntType(12.12), "12i"],
+            [new IntType("12.12"), "12i"],
+            ["invalid", "0i"],
+            [null, "0i"],
+            [new IntType("invalid"), "0i"],
+            [new IntType(null), "0i"],
+            [true, "1i"],
+            [false, "0i"],
+        ];
+    }
+}

--- a/tests/unit/Type/StringTypeTest.php
+++ b/tests/unit/Type/StringTypeTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace InfluxDB\Type;
+
+class StringTypeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider stringProvider
+     */
+    public function testConversions($in, $out)
+    {
+        $this->assertEquals($out, new StringType($in));
+    }
+
+    public function stringProvider()
+    {
+        return [
+            [true, '"1"'],
+            ["walter", '"walter"'],
+            ["12", '"12"'],
+            ["12.153", '"12.153"'],
+            [12.153, '"12.153"'],
+            [12, '"12"'],
+        ];
+    }
+}
+
+


### PR DESCRIPTION
Instead of switch case management, i try another way using callables in order to convert data-type to InfluxDB