### PR TITLE
Refactored `InfluxDB\Options` for Readers\Writers

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,14 @@ In order to use the UDP/IP adapter your must have PHP compiled with the `sockets
 ```php
 $reader = ...
 
-$options = new Options();
+$options = new Udp\Options();
 $writer = new Udp\Writer($options);
 
 $client = new Client($reader, $writer);
 ```
+
+_UDP/IP option set have only `host` and `port` properties you configure
+database and retention policies directly in your InfluxDB configuration_
 
 ### Using HTTP Adapters
 
@@ -100,7 +103,7 @@ $http = new \GuzzleHttp\Client();
 
 $writer = ...
 
-$options = new Options();
+$options = new Http\Options();
 $reader = new Http\Reader($http, $options);
 
 $client = new Client($reader, $writer);
@@ -195,7 +198,7 @@ $client->deleteDatabase("my-name"); // delete an existing database with name "my
 You can set a set of default tags, that the SDK will add to your metrics:
 
 ```php
-$options = new Options();
+$options = new Http\Options();
 $options->setTags([
     "env" => "prod",
     "region" => "eu-west-1",

--- a/src/Adapter/Http/Options.php
+++ b/src/Adapter/Http/Options.php
@@ -1,6 +1,5 @@
 <?php
-
-namespace InfluxDB;
+namespace InfluxDB\Adapter\Http;
 
 class Options
 {

--- a/src/Adapter/Http/Reader.php
+++ b/src/Adapter/Http/Reader.php
@@ -1,7 +1,7 @@
 <?php
 namespace InfluxDB\Adapter\Http;
 
-use InfluxDB\Options;
+use InfluxDB\Adapter\Http\Options;
 use GuzzleHttp\Client;
 use InfluxDB\Adapter\QueryableInterface;
 

--- a/src/Adapter/Http/Writer.php
+++ b/src/Adapter/Http/Writer.php
@@ -1,19 +1,24 @@
 <?php
 namespace InfluxDB\Adapter\Http;
 
-use InfluxDB\Options;
 use GuzzleHttp\Client;
+use InfluxDB\Adapter\Http\Options;
 use InfluxDB\Adapter\WriterAbstract;
 
 class Writer extends WriterAbstract
 {
     private $httpClient;
+    private $options;
 
     public function __construct(Client $httpClient, Options $options)
     {
-        parent::__construct($options);
-
         $this->httpClient = $httpClient;
+        $this->options = $options;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
     }
 
     public function send(array $message)
@@ -24,7 +29,7 @@ class Writer extends WriterAbstract
                 "db" => $this->getOptions()->getDatabase(),
                 "retentionPolicy" => $this->getOptions()->getRetentionPolicy(),
             ],
-            "body" => $this->messageToLineProtocol($message)
+            "body" => $this->messageToLineProtocol($message, $this->getOptions()->getTags())
         ];
 
         $endpoint = $this->getHttpSeriesEndpoint();

--- a/src/Adapter/Udp/Options.php
+++ b/src/Adapter/Udp/Options.php
@@ -1,0 +1,50 @@
+<?php
+namespace InfluxDB\Adapter\Udp;
+
+class Options
+{
+    private $host;
+    private $port;
+    private $tags;
+
+    public function __construct()
+    {
+        $this->setHost("localhost");
+        $this->setTags([]);
+        $this->setPort(4444);
+    }
+
+    public function getPort()
+    {
+        return $this->port;
+    }
+
+    public function setPort($port)
+    {
+        $this->port = $port;
+        return $this;
+    }
+
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    public function setTags($tags)
+    {
+        $this->tags = $tags;
+        return $this;
+    }
+
+    public function getHost()
+    {
+       return $this->host;
+    }
+
+    public function setHost($host)
+    {
+        $this->host = $host;
+        return $this;
+    }
+}
+

--- a/src/Adapter/Udp/Writer.php
+++ b/src/Adapter/Udp/Writer.php
@@ -2,12 +2,24 @@
 namespace InfluxDB\Adapter\Udp;
 
 use InfluxDB\Adapter\WriterAbstract;
+use InfluxDB\Adapter\Udp\Options;
 
 class Writer extends WriterAbstract
 {
+    private $options;
+
+    public function __construct(Options $options)
+    {
+        $this->options = $options;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
     public function send(array $message)
     {
-        $message = $this->messageToLineProtocol($message);
+        $message = $this->messageToLineProtocol($message, $this->getOptions()->getTags());
 
         $this->write($message);
     }

--- a/src/Adapter/WriterAbstract.php
+++ b/src/Adapter/WriterAbstract.php
@@ -2,33 +2,20 @@
 namespace InfluxDB\Adapter;
 
 use DateTime;
-use InfluxDB\Options;
 use InfluxDB\Adapter\WritableInterface;
 
 abstract class WriterAbstract implements WritableInterface
 {
-    private $options;
-
-    public function __construct(Options $options)
-    {
-        $this->options = $options;
-    }
-
-    public function getOptions()
-    {
-        return $this->options;
-    }
-
     abstract public function send(array $message);
 
-    protected function messageToLineProtocol(array $message)
+    protected function messageToLineProtocol(array $message, array $tags = [])
     {
         if (!array_key_exists("points", $message)) {
             return;
         }
 
         $message = $this->prepareMessageSection($message);
-        $message["tags"] = array_replace_recursive($this->getOptions()->getTags(), $message["tags"]);
+        $message["tags"] = array_replace_recursive($tags, $message["tags"]);
 
         $lines = [];
         foreach ($message["points"] as $point) {

--- a/tests/integration/Adapter/Http/WriterTest.php
+++ b/tests/integration/Adapter/Http/WriterTest.php
@@ -3,8 +3,8 @@ namespace InfluxDB\Integration\Adapter\Http;
 
 use DateTime;
 use DateTimeZone;
-use InfluxDB\Options;
 use InfluxDB\Client;
+use InfluxDB\Adapter\Http\Options;
 use GuzzleHttp\Client as GuzzleHttpClient;
 use InfluxDB\Integration\Framework\TestCase as InfluxDBTestCase;
 use InfluxDB\Adapter\Http\Writer;

--- a/tests/integration/Adapter/Udp/WriterTest.php
+++ b/tests/integration/Adapter/Udp/WriterTest.php
@@ -1,15 +1,15 @@
 <?php
 namespace InfluxDB\Integration\Adapter\Udp;
 
-use InfluxDB\Integration\Framework\TestCase as InfluxDBTestCase;
-use InfluxDB\Options;
 use InfluxDB\Adapter\Udp\Writer;
+use InfluxDB\Adapter\Udp\Options as UdpOptions;
+use InfluxDB\Integration\Framework\TestCase as InfluxDBTestCase;
 
 class WriterTest extends InfluxDBTestCase
 {
     public function testWriteSimplePointsUsingDirectWrite()
     {
-        $options = (new Options())->setPort(4444);
+        $options = (new UdpOptions())->setPort(4444);
         $adapter = new Writer($options);
 
         $this->getClient()->createDatabase("udp.test");
@@ -26,11 +26,11 @@ class WriterTest extends InfluxDBTestCase
     /**
      * @dataProvider getDifferentOptions
      */
-    public function testWriteSimplePointsUsingSendMethod(Options $options)
+    public function testWriteSimplePointsUsingSendMethod(UdpOptions $options)
     {
         $adapter = new Writer($options);
 
-        $this->getClient()->createDatabase($options->getDatabase());
+        $this->getClient()->createDatabase("udp.test");
 
         $adapter->send([
             "retentionPolicy" => "default",
@@ -49,18 +49,18 @@ class WriterTest extends InfluxDBTestCase
 
         sleep(2);
 
-        $this->assertSerieExists($options->getDatabase(), "mem");
-        $this->assertSerieCount($options->getDatabase(), "mem", 1);
-        $this->assertValueExistsInSerie($options->getDatabase(), "mem", "value", 1233);
-        $this->assertValueExistsInSerie($options->getDatabase(), "mem", "value_float", 1233.34);
-        $this->assertValueExistsInSerie($options->getDatabase(), "mem", "with_string", "this is a string");
-        $this->assertValueExistsInSerie($options->getDatabase(), "mem", "with_bool", true);
+        $this->assertSerieExists("udp.test", "mem");
+        $this->assertSerieCount("udp.test", "mem", 1);
+        $this->assertValueExistsInSerie("udp.test", "mem", "value", 1233);
+        $this->assertValueExistsInSerie("udp.test", "mem", "value_float", 1233.34);
+        $this->assertValueExistsInSerie("udp.test", "mem", "with_string", "this is a string");
+        $this->assertValueExistsInSerie("udp.test", "mem", "with_bool", true);
     }
 
     public function getDifferentOptions()
     {
         return [
-            [(new Options())->setPort(4444)->setDatabase("udp.test")],
+            [(new UdpOptions())->setPort(4444)],
         ];
     }
 }

--- a/tests/integration/ClientTest.php
+++ b/tests/integration/ClientTest.php
@@ -3,7 +3,7 @@ namespace InfluxDB\Integration;
 
 use DateTime;
 use DateTimeZone;
-use InfluxDB\Options;
+use InfluxDB\Adapter\Http\Options;
 use InfluxDB\Adapter\UdpAdapter;
 use InfluxDB\Adapter\GuzzleAdapter as InfluxHttpAdapter;
 use GuzzleHttp\Client as GuzzleHttpClient;
@@ -121,18 +121,15 @@ class ClientTest extends TestCase
      */
     public function testReplicateIssue27()
     {
-        $options = new \InfluxDB\Options();
+        $options = new \InfluxDB\Adapter\Udp\Options();
 
         // Configure options
         $options->setHost('172.16.1.182');
         $options->setPort(4444);
-        $options->setDatabase('...');
-        $options->setUsername('root');
-        $options->setPassword('root');
 
         $guzzleHttp = new GuzzleHttpClient();
         $writer = new UdpWriter($options);
-        $reader = new Reader($guzzleHttp, $options);
+        $reader = new Reader($guzzleHttp, new Options());
         $client = new Client($reader, $writer);
         $client->mark("udp.test", ["mark" => "element"]);
     }
@@ -142,15 +139,13 @@ class ClientTest extends TestCase
      */
     public function testWriteUDPPackagesToNoOne()
     {
-        $options = new Options();
+        $options = new \InfluxDB\Adapter\Udp\Options();
         $options->setHost("127.0.0.1");
-        $options->setUsername("nothing");
-        $options->setPassword("nothing");
         $options->setPort(64071); //This is a wrong port
 
         $guzzleHttp = new GuzzleHttpClient();
         $writer = new UdpWriter($options);
-        $reader = new Reader($guzzleHttp, $options);
+        $reader = new Reader($guzzleHttp, new Options());
         $client = new Client($reader, $writer);
 
         $client->mark("udp.test", ["mark" => "element"]);
@@ -161,15 +156,13 @@ class ClientTest extends TestCase
      */
     public function testWriteUDPPackagesToInvalidHostname()
     {
-        $options = new Options();
+        $options = new \InfluxDB\Adapter\Udp\Options();
         $options->setHost("www.test-invalid.this-is-not-a-tld");
-        $options->setUsername("nothing");
-        $options->setPassword("nothing");
         $options->setPort(15984);
 
         $guzzleHttp = new GuzzleHttpClient();
         $writer = new UdpWriter($options);
-        $reader = new Reader($guzzleHttp, $options);
+        $reader = new Reader($guzzleHttp, new Options());
         $client = new Client($reader, $writer);
 
         $client->mark("udp.test", ["mark" => "element"]);

--- a/tests/integration/Framework/TestCase.php
+++ b/tests/integration/Framework/TestCase.php
@@ -1,9 +1,9 @@
 <?php
 namespace InfluxDB\Integration\Framework;
 
-use InfluxDB\Options;
 use GuzzleHttp\Client as GuzzleHttpClient;
 use InfluxDB\Client;
+use InfluxDB\Adapter\Http\Options as HttpOptions;
 use InfluxDB\Adapter\Http\Writer;
 use InfluxDB\Adapter\Http\Reader;
 
@@ -14,7 +14,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $options = $this->options = new Options();
+        $options = $this->options = new HttpOptions();
         $guzzleHttp = new GuzzleHttpClient();
         $writer = new Writer($guzzleHttp, $options);
         $reader = new Reader($guzzleHttp, $options);

--- a/tests/unit/Adapter/Http/ReaderTest.php
+++ b/tests/unit/Adapter/Http/ReaderTest.php
@@ -3,10 +3,10 @@ namespace InfluxDB\Adapter\Http;
 
 use DateTime;
 use DateTimeZone;
-use InfluxDB\Options;
-use GuzzleHttp\Client as GuzzleHttpClient;
 use InfluxDB\Client;
 use Prophecy\Argument;
+use InfluxDB\Adapter\Http\Options;
+use GuzzleHttp\Client as GuzzleHttpClient;
 
 class ReaderTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/unit/Adapter/Http/WriterTest.php
+++ b/tests/unit/Adapter/Http/WriterTest.php
@@ -3,7 +3,7 @@ namespace InfluxDB\Adapter\Http;
 
 use DateTime;
 use DateTimeZone;
-use InfluxDB\Options;
+use InfluxDB\Adapter\Http\Options;
 use GuzzleHttp\Client as GuzzleHttpClient;
 use InfluxDB\Client;
 use Prophecy\Argument;

--- a/tests/unit/Adapter/Udp/WriterTest.php
+++ b/tests/unit/Adapter/Udp/WriterTest.php
@@ -3,7 +3,7 @@ namespace InfluxDB\Adapter\Udp;
 
 use DateTime;
 use DateTimeZone;
-use InfluxDB\Options;
+use InfluxDB\Adapter\Udp\Options;
 use GuzzleHttp\Client as GuzzleHttpClient;
 use InfluxDB\Adapter\GuzzleAdapter as InfluxHttpAdapter;
 use InfluxDB\Client;
@@ -119,7 +119,7 @@ EOF
      */
     public function testUdpIpWriteDataWillBeConvertedAsLineProtocol()
     {
-        $options = (new Options())->setDatabase("test");
+        $options = new Options();
         $adapter = $this->getMockBuilder("InfluxDB\\Adapter\\Udp\\Writer")
             ->setConstructorArgs([$options])
             ->setMethods(["write", "generateTimeInNanoSeconds"])
@@ -150,7 +150,7 @@ EOF
      */
     public function testSendMultipleMeasurementWithUdpIp()
     {
-        $options = (new Options())->setDatabase("test");
+        $options = new Options();
         $adapter = $this->getMockBuilder("InfluxDB\\Adapter\\Udp\\Writer")
             ->setConstructorArgs([$options])
             ->setMethods(["write", "generateTimeInNanoSeconds"])
@@ -191,9 +191,7 @@ EOF
      */
     public function testFillWithGlobalTags()
     {
-        $options = (new Options())
-            ->setDatabase("test")
-            ->setTags(["dc" => "eu-west"]);
+        $options = (new Options())->setTags(["dc" => "eu-west"]);
         $adapter = $this->getMockBuilder("InfluxDB\\Adapter\\Udp\\Writer")
             ->setConstructorArgs([$options])
             ->setMethods(["write"])
@@ -221,7 +219,6 @@ EOF
     public function testMergeGlobalTags()
     {
         $options = (new Options())
-            ->setDatabase("test")
             ->setTags(["dc" => "eu-west"]);
         $adapter = $this->getMockBuilder("InfluxDB\\Adapter\\Udp\\Writer")
             ->setConstructorArgs([$options])
@@ -260,7 +257,6 @@ EOF
     public function testMergeFullTagsPositions()
     {
         $options = (new Options())
-            ->setDatabase("test")
             ->setTags(["dc" => "eu-west"]);
         $adapter = $this->getMockBuilder("InfluxDB\\Adapter\\Udp\\Writer")
             ->setConstructorArgs([$options])

--- a/tests/unit/Adapter/WriterAbstractTest.php
+++ b/tests/unit/Adapter/WriterAbstractTest.php
@@ -2,7 +2,6 @@
 namespace InfluxDB\Adapter;
 
 use ReflectionMethod;
-use InfluxDB\Options;
 use InfluxDB\Type\IntType;
 use InfluxDB\Type\FloatType;
 
@@ -11,10 +10,9 @@ class WriterAbstractTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getElements
      */
-    public function testListToLineValues($message, $result, $options)
+    public function testListToLineValues($message, $result)
     {
         $helper = $this->getMockBuilder("InfluxDB\\Adapter\\WriterAbstract")
-            ->setConstructorArgs([$options])
             ->getMockForAbstractClass();
 
         $method = new ReflectionMethod(get_class($helper), "pointsToString");
@@ -26,24 +24,24 @@ class WriterAbstractTest extends \PHPUnit_Framework_TestCase
     public function getElements()
     {
         return [
-            [["one" => "two"], "one=\"two\"", new Options()],
-            [["one" => "two", "three" => "four"], "one=\"two\",three=\"four\"", new Options()],
-            [["one" => true, "three" => false], "one=true,three=false", new Options()],
-            [["one" => true, "three" => 0., "four" => 1.], "one=true,three=0,four=1", new Options()],
-            [["one" => true, "three" => false], "one=true,three=false", new Options()],
-            [["one" => true, "three" => 0, "four" => 1], "one=true,three=0i,four=1i", new Options()],
-            [["one" => 12, "three" => 14], "one=12i,three=14i", (new Options())],
-            [["one" => 12.1, "three" => 14], "one=12.1,three=14i", (new Options())],
-            [["one" => 12., "three" => 14], "one=12,three=14i", (new Options())],
-            [["one" => (double)12, "three" => 14], "one=12,three=14i", (new Options())],
-            [["one" => (double)12, "three" => (double)14], "one=12,three=14", (new Options())],
-            [["one" => (double)"12", "three" => (int)"14"], "one=12,three=14i", (new Options())],
-            [["one" => (double)"12", "three" => new IntType("14")], "one=12,three=14i", (new Options())],
-            [["one" => (double)"12", "three" => new IntType(14.12)], "one=12,three=14i", (new Options())],
-            [["one" => (double)"12", "three" => new IntType(14)], "one=12,three=14i", (new Options())],
-            [["one" => (double)"12", "three" => new FloatType(14)], "one=12,three=14", (new Options())],
-            [["one" => (double)"12", "three" => new FloatType("14")], "one=12,three=14", (new Options())],
-            [["one" => (double)"12", "three" => new FloatType("14.123")], "one=12,three=14.123", (new Options())],
+            [["one" => "two"], "one=\"two\""],
+            [["one" => "two", "three" => "four"], "one=\"two\",three=\"four\""],
+            [["one" => true, "three" => false], "one=true,three=false"],
+            [["one" => true, "three" => 0., "four" => 1.], "one=true,three=0,four=1"],
+            [["one" => true, "three" => false], "one=true,three=false"],
+            [["one" => true, "three" => 0, "four" => 1], "one=true,three=0i,four=1i"],
+            [["one" => 12, "three" => 14], "one=12i,three=14i"],
+            [["one" => 12.1, "three" => 14], "one=12.1,three=14i"],
+            [["one" => 12., "three" => 14], "one=12,three=14i"],
+            [["one" => (double)12, "three" => 14], "one=12,three=14i"],
+            [["one" => (double)12, "three" => (double)14], "one=12,three=14"],
+            [["one" => (double)"12", "three" => (int)"14"], "one=12,three=14i"],
+            [["one" => (double)"12", "three" => new IntType("14")], "one=12,three=14i"],
+            [["one" => (double)"12", "three" => new IntType(14.12)], "one=12,three=14i"],
+            [["one" => (double)"12", "three" => new IntType(14)], "one=12,three=14i"],
+            [["one" => (double)"12", "three" => new FloatType(14)], "one=12,three=14"],
+            [["one" => (double)"12", "three" => new FloatType("14")], "one=12,three=14"],
+            [["one" => (double)"12", "three" => new FloatType("14.123")], "one=12,three=14.123"],
         ];
     }
 }


### PR DESCRIPTION
Network adapters have different option set

 * HTTP use a big set of available options (retention policies, etc...)
 * UDP/IP use only Host and Port options

In this commit we drop out the single option class (`InfluxDB\Options`).
That was confusing with the UDP/IP writer.

This fixes #60 