### PR TITLE
Use trait insted of WriterAbstract

### DIFF
--- a/src/Adapter/Http/Writer.php
+++ b/src/Adapter/Http/Writer.php
@@ -2,11 +2,14 @@
 namespace InfluxDB\Adapter\Http;
 
 use GuzzleHttp\Client;
+use InfluxDB\Adapter\WriterTrait;
 use InfluxDB\Adapter\Http\Options;
-use InfluxDB\Adapter\WriterAbstract;
+use InfluxDB\Adapter\WritableInterface;
 
-class Writer extends WriterAbstract
+class Writer implements WritableInterface
 {
+    use WriterTrait;
+
     private $httpClient;
     private $options;
 

--- a/src/Adapter/Udp/Writer.php
+++ b/src/Adapter/Udp/Writer.php
@@ -1,11 +1,14 @@
 <?php
 namespace InfluxDB\Adapter\Udp;
 
-use InfluxDB\Adapter\WriterAbstract;
+use InfluxDB\Adapter\WriterTrait;
 use InfluxDB\Adapter\Udp\Options;
+use InfluxDB\Adapter\WritableInterface;
 
-class Writer extends WriterAbstract
+class Writer implements WritableInterface
 {
+    use WriterTrait;
+
     private $options;
 
     public function __construct(Options $options)

--- a/src/Adapter/WriterTrait.php
+++ b/src/Adapter/WriterTrait.php
@@ -2,13 +2,10 @@
 namespace InfluxDB\Adapter;
 
 use DateTime;
-use InfluxDB\Adapter\WritableInterface;
 
-abstract class WriterAbstract implements WritableInterface
+trait WriterTrait
 {
-    abstract public function send(array $message);
-
-    protected function messageToLineProtocol(array $message, array $tags = [])
+    public function messageToLineProtocol(array $message, array $tags = [])
     {
         if (!array_key_exists("points", $message)) {
             return;

--- a/tests/unit/Adapter/WriterTraitTest.php
+++ b/tests/unit/Adapter/WriterTraitTest.php
@@ -5,15 +5,15 @@ use ReflectionMethod;
 use InfluxDB\Type\IntType;
 use InfluxDB\Type\FloatType;
 
-class WriterAbstractTest extends \PHPUnit_Framework_TestCase
+class WriterTraitTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider getElements
      */
     public function testListToLineValues($message, $result)
     {
-        $helper = $this->getMockBuilder("InfluxDB\\Adapter\\WriterAbstract")
-            ->getMockForAbstractClass();
+        $helper = $this->getMockBuilder("InfluxDB\\Adapter\\WriterTrait")
+            ->getMockForTrait();
 
         $method = new ReflectionMethod(get_class($helper), "pointsToString");
         $method->setAccessible(true);


### PR DESCRIPTION
In order to separate completely Http\Writer and Udp\Writer we could use
`WriterTrait` instead of `WriterAbstract` and inheritance.

This solution is more decoupled than the inheritance based solution.