### PR TITLE
Support for custom query manager

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -45,22 +45,4 @@ class Client
     {
         return $this->getReader()->query($query);
     }
-
-    public function getDatabases()
-    {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 0.8.1 and will be removed in 0.9.', E_USER_DEPRECATED);
-        return $this->query("show databases");
-    }
-
-    public function createDatabase($name)
-    {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 0.8.1 and will be removed in 0.9.', E_USER_DEPRECATED);
-        return $this->query("create database \"{$name}\"");
-    }
-
-    public function deleteDatabase($name)
-    {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 0.8.1 and will be removed in 0.9.', E_USER_DEPRECATED);
-        return $this->query("drop database \"{$name}\"");
-    }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -1,0 +1,52 @@
+<?php
+namespace InfluxDB;
+
+use InvalidArgumentException;
+use RuntimeException;
+use InfluxDB\Client;
+
+class Manager
+{
+    private $client;
+    private $queries;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+        $this->queries = [];
+    }
+
+    public function addQuery($name, callable $query = null)
+    {
+        if ($query === null) {
+            list($name, $query) = $this->fromObjectToNameCallableList($name);
+        }
+
+        $this->queries[$name] = $query;
+    }
+
+    private function fromObjectToNameCallableList($name)
+    {
+        if (is_object($name) && is_callable($name)) {
+            if (method_exists($name, "__toString")) {
+                return [(string)$name, $name];
+            }
+        }
+
+        throw new InvalidArgumentException("Your command should implements '__toString' method and should be a callable thing");
+    }
+
+    public function __call($name, $args)
+    {
+        if (method_exists($this->client, $name)) {
+            return call_user_func_array([$this->client, $name], $args);
+        }
+
+        if (array_key_exists($name, $this->queries)) {
+            $query = call_user_func_array($this->queries[$name], $args);
+            return $this->client->query($query);
+        }
+
+        throw new RuntimeException("The method you are using is not allowed: '{$name}', do you have to add it with 'addQuery'");
+    }
+}

--- a/src/Query/CreateDatabase.php
+++ b/src/Query/CreateDatabase.php
@@ -1,0 +1,15 @@
+<?php
+namespace InfluxDB\Query;
+
+class CreateDatabase
+{
+    public function __invoke($name)
+    {
+        return "CREATE DATABASE \"" . addslashes($name) . "\"";
+    }
+
+    public function __toString()
+    {
+        return "createDatabase";
+    }
+}

--- a/src/Query/DeleteDatabase.php
+++ b/src/Query/DeleteDatabase.php
@@ -1,0 +1,16 @@
+<?php
+namespace InfluxDB\Query;
+
+class DeleteDatabase
+{
+    public function __invoke($name)
+    {
+        return "DROP DATABASE \"" . addslashes($name) . "\"";
+    }
+
+    public function __toString()
+    {
+        return "deleteDatabase";
+    }
+}
+

--- a/src/Query/GetDatabases.php
+++ b/src/Query/GetDatabases.php
@@ -1,0 +1,17 @@
+<?php
+namespace InfluxDB\Query;
+
+class GetDatabases
+{
+    public function __invoke()
+    {
+        return "show databases";
+    }
+
+    public function __toString()
+    {
+        return "getDatabases";
+    }
+}
+
+

--- a/tests/integration/ClientTest.php
+++ b/tests/integration/ClientTest.php
@@ -70,49 +70,6 @@ class ClientTest extends TestCase
         $this->assertValueExistsInSerie("tcp.test", "tt", "mem", 2);
     }
 
-    public function testListActiveDatabases()
-    {
-        $options = new Options();
-        $guzzleHttp = new GuzzleHttpClient();
-        $writer = new Writer($guzzleHttp, $options);
-        $reader = new Reader($guzzleHttp, $options);
-        $client = new Client($reader, $writer);
-
-        $databases = $client->getDatabases();
-
-        $this->assertCount(2, $databases["results"][0]["series"][0]["values"]);
-    }
-
-    public function testCreateANewDatabase()
-    {
-        $options = new Options();
-        $guzzleHttp = new GuzzleHttpClient();
-        $writer = new Writer($guzzleHttp, $options);
-        $reader = new Reader($guzzleHttp, $options);
-        $client = new Client($reader, $writer);
-
-        $client->createDatabase("walter");
-
-        $databases = $client->getDatabases();
-
-        $this->assertCount(3, $databases["results"][0]["series"][0]["values"]);
-    }
-
-    public function testDropExistingDatabase()
-    {
-        $options = new Options();
-        $guzzleHttp = new GuzzleHttpClient();
-        $writer = new Writer($guzzleHttp, $options);
-        $reader = new Reader($guzzleHttp, $options);
-        $client = new Client($reader, $writer);
-
-        $client->createDatabase("walter");
-        $this->assertDatabasesCount(3);
-
-        $client->deleteDatabase("walter");
-        $this->assertDatabasesCount(2);
-    }
-
     /**
      * Test that we handle socket problems correctly in the UDP
      * adapter, and that they don't inturrupt the user's application.

--- a/tests/integration/ManagerTest.php
+++ b/tests/integration/ManagerTest.php
@@ -1,0 +1,79 @@
+<?php
+namespace InfluxDB\Integration;
+
+use InfluxDB\Adapter\Http\Options;
+use InfluxDB\Adapter\Http\Writer;
+use InfluxDB\Adapter\Http\Reader;
+use InfluxDB\Client;
+use InfluxDB\Query\CreateDatabase;
+use InfluxDB\Query\DeleteDatabase;
+use InfluxDB\Query\GetDatabases;
+use GuzzleHttp\Client as GuzzleHttpClient;
+use InfluxDB\Manager;
+use InfluxDB\Integration\Framework\TestCase;
+
+class ManagerTest extends TestCase
+{
+    public function testCreateANewDatabase()
+    {
+        $options = new Options();
+        $guzzleHttp = new GuzzleHttpClient();
+        $writer = new Writer($guzzleHttp, $options);
+        $reader = new Reader($guzzleHttp, $options);
+        $client = new Client($reader, $writer);
+        $manager = new Manager($client);
+
+        $manager->addQuery(new CreateDatabase());
+        $manager->addQuery(new DeleteDatabase());
+        $manager->addQuery(new GetDatabases());
+
+        $manager->createDatabase("one");
+        $manager->createDatabase("two");
+        $manager->createDatabase("walter");
+
+        $databases = $manager->getDatabases();
+
+        $this->assertCount(3, $databases["results"][0]["series"][0]["values"]);
+    }
+
+    public function testDropExistingDatabase()
+    {
+        $options = new Options();
+        $guzzleHttp = new GuzzleHttpClient();
+        $writer = new Writer($guzzleHttp, $options);
+        $reader = new Reader($guzzleHttp, $options);
+        $client = new Client($reader, $writer);
+        $manager = new Manager($client);
+
+        $manager->addQuery(new CreateDatabase());
+        $manager->addQuery(new DeleteDatabase());
+        $manager->addQuery(new GetDatabases());
+
+        $manager->createDatabase("walter");
+        $this->assertDatabasesCount(1);
+
+        $manager->deleteDatabase("walter");
+        $this->assertDatabasesCount(0);
+    }
+
+    public function testListActiveDatabases()
+    {
+        $options = new Options();
+        $guzzleHttp = new GuzzleHttpClient();
+        $writer = new Writer($guzzleHttp, $options);
+        $reader = new Reader($guzzleHttp, $options);
+        $client = new Client($reader, $writer);
+        $manager = new Manager($client);
+
+        $manager->addQuery(new CreateDatabase());
+        $manager->addQuery(new DeleteDatabase());
+        $manager->addQuery(new GetDatabases());
+
+        $manager->createDatabase("one");
+        $manager->createDatabase("two");
+
+        $databases = $manager->getDatabases();
+
+        $this->assertCount(2, $databases["results"][0]["series"][0]["values"]);
+    }
+}

--- a/tests/unit/ManagerTest.php
+++ b/tests/unit/ManagerTest.php
@@ -1,0 +1,114 @@
+<?php
+namespace InfluxDB;
+
+use Prophecy\Argument;
+
+class ManagerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testQueryCommandWithCallables()
+    {
+        $client = $this->prophesize("InfluxDB\Client");
+        $client->query("CREATE DATABASE mydb")->shouldBeCalledTimes(1);
+
+        $manager = new Manager($client->reveal());
+        $manager->addQuery("createDatabase", function($name) {
+            return "CREATE DATABASE {$name}";
+        });
+
+        $manager->createDatabase("mydb");
+    }
+
+    public function testQueryCommandReturnsTheCommandData()
+    {
+        $client = $this->prophesize("InfluxDB\Client");
+        $client->query(Argument::Any())->willReturn("OK");
+
+        $manager = new Manager($client->reveal());
+        $manager->addQuery("anything", function() {});
+
+        $data = $manager->anything();
+        $this->assertEquals("OK", $data);
+    }
+
+    public function testInvokableCommands()
+    {
+        $client = $this->prophesize("InfluxDB\Client");
+        $client->query("CREATE DATABASE mydb")->shouldBeCalledTimes(1);
+
+        $manager = new Manager($client->reveal());
+        $manager->addQuery(new CreateDatabaseMock());
+
+        $manager->createDatabase("mydb");
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testNotCallableMethods()
+    {
+        $client = $this->prophesize("InfluxDB\Client");
+
+        $manager = new Manager($client->reveal());
+        $manager->addQuery(new NotCallable());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testClassWithoutNameException()
+    {
+        $client = $this->prophesize("InfluxDB\Client");
+
+        $manager = new Manager($client->reveal());
+        $manager->addQuery(new NoName());
+    }
+
+    public function testFallbackToClientMethods()
+    {
+        $client = $this->prophesize("InfluxDB\Client");
+        $client->mark("hello", ["data" => true])->shouldBeCalledTimes(1);
+
+        $manager = new Manager($client->reveal());
+        $manager->mark("hello", ["data" => true]);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The method you are using is not allowed: 'missingMethod', do you have to add it with 'addQuery'
+     */
+    public function testCallMissingMethod()
+    {
+        $client = $this->prophesize("InfluxDB\Client");
+        $manager = new Manager($client->reveal());
+        $manager->missingMethod();
+    }
+}
+
+class NoName
+{
+    public function __invoke($args)
+    {
+        return "TEST";
+    }
+}
+
+class NotCallable
+{
+    public function __toString()
+    {
+        return "hello";
+    }
+}
+
+class CreateDatabaseMock
+{
+    public function __invoke($name)
+    {
+        return "CREATE DATABASE {$name}";
+    }
+
+    public function __toString()
+    {
+        return "createDatabase";
+    }
+}

--- a/tests/unit/Query/CreateDatabaseTest.php
+++ b/tests/unit/Query/CreateDatabaseTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace InfluxDB\Query;
+
+class CreateDatabaseTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider queries
+     */
+    public function testCreateDatabaseQuery($name, $query)
+    {
+        $db = new CreateDatabase();
+        $res = $db($name);
+
+        $this->assertEquals($query, $res);
+    }
+
+    public function queries()
+    {
+        return [
+            ["mydb", 'CREATE DATABASE "mydb"'],
+            ['my"db"', 'CREATE DATABASE "my\"db\""'],
+            ["my'db'", "CREATE DATABASE \"my\'db\'\""],
+        ];
+    }
+}

--- a/tests/unit/Query/DeleteDatabaseTest.php
+++ b/tests/unit/Query/DeleteDatabaseTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace InfluxDB\Query;
+
+class DeleteDatabaseTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider queries
+     */
+    public function testDeleteDatabaseQuery($name, $query)
+    {
+        $db = new DeleteDatabase();
+        $res = $db($name);
+
+        $this->assertEquals($query, $res);
+    }
+
+    public function queries()
+    {
+        return [
+            ["mydb", 'DROP DATABASE "mydb"'],
+            ['my"db"', 'DROP DATABASE "my\"db\""'],
+            ["my'db'", "DROP DATABASE \"my\'db\'\""],
+        ];
+    }
+}
+

--- a/tests/unit/Query/GetDatabasesTest.php
+++ b/tests/unit/Query/GetDatabasesTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace InfluxDB\Query;
+
+class GetDatabasesTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetDatabasesQuery()
+    {
+        $db = new GetDatabases();
+        $res = $db();
+
+        $this->assertEquals("show databases", $res);
+    }
+}
+
+


### PR DESCRIPTION
Instead of mapping all database specific queries like: `createDatabase`
or `getDatabases` directly in the `InfluxDB\Client` class we can prepare
a manager that will enable any user to create custom queries and release
them out. In addition a preset of queries like: `'SHOW DATABASES'` and
any ordinary query set is included as part of this project.

The manager uses a simple way to add new queries:

```php
$manager = new Manager($client);
$manager->addQuery("myQuery", function($arg1, $arg2) {
    return sprintf("THIS IS A CUSTOM QUERY WITH: %s %s", $arg1, $arg2);
});

//Use it
$manager->myQuery("test", "ok");
```

Thanks to PHP we can also use objects in order to create a valid
commands in a more concise way:

```php
class MyCommand
{
    public function __toString()
    {
        return "myCommand";
    }

    public function __invoke()
    {
        return "HERE IS MY COMMAND";
    }
}

$manager->addQuery(new MyCommand());

$data = $manager->myCommand();
```

This features release a preset of queries (not engaged by default
anymore):

```php
$manager->addQuery(new CreateDatabase()); //create database command
$manager->addQuery(new DeleteDatabase()); //drop database command
$manager->addQuery(new GetDatabases());   //list existing databases
```