### PR TITLE
Exclude empty elements from messageToLineProtocol 

### DIFF
--- a/src/Adapter/WriterTrait.php
+++ b/src/Adapter/WriterTrait.php
@@ -63,17 +63,18 @@ trait WriterTrait
 
     protected function pointsToString(array $elements)
     {
-        $elements = array_filter($elements);
         array_walk($elements, function(&$value, $key) {
             $dataType = gettype($value);
             if (!in_array($dataType, ["string", "double", "boolean", "integer"])) {
                 $dataType = "serializable";
             }
             $dataType = ucfirst($dataType);
-            $value = call_user_func([$this, "convert{$dataType}"], $value);
-            $value = "{$key}={$value}";
+            if ($dataType!='Null') {
+                $value = call_user_func([$this, "convert{$dataType}"], $value);
+                $value = "{$key}={$value}";
+            }
         });
-
+        $elements = array_filter($elements);
         return implode(",", $elements);
     }
 

--- a/src/Adapter/WriterTrait.php
+++ b/src/Adapter/WriterTrait.php
@@ -63,6 +63,7 @@ trait WriterTrait
 
     protected function pointsToString(array $elements)
     {
+        $elements = array_filter($elements);
         array_walk($elements, function(&$value, $key) {
             $dataType = gettype($value);
             if (!in_array($dataType, ["string", "double", "boolean", "integer"])) {


### PR DESCRIPTION
messageToLineProtocol would create invalid output in case of empty fields in a mark.

Example:

```php
mark("dev", [
        "hello" => "world",
        "bug" => null,
        "value" => 1.23
    ]);
```

This would output a line like this:
```
dev hello="world",bug=,value=1.23 
```
This appears to be invalid syntax, and the message would be discarded by influxdb. Takes a while to figure that out as there are no response codes. I discovered this while pasting the invalid line in the influxdb ui.

after this patch, the line will look like this:
```
dev hello="world",value=1.23 
```

Hope this helps!